### PR TITLE
.config

### DIFF
--- a/.config
+++ b/.config
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2006-2013 OpenWrt.org
+
+mainmenu "OpenWrt Configuration"
+
+config MODULES
+	option modules
+	bool
+	default y
+
+config HAVE_DOT_CONFIG
+	bool
+	default y
+
+HOST_OS := $(shell, uname)
+
+config HOST_OS_LINUX
+	def_bool $(shell, ./config/check-uname.sh Linux)
+
+config HOST_OS_MACOS
+	def_bool $(shell, ./config/check-uname.sh Darwin)
+
+source "target/Config.in"
+
+source "config/Config-images.in"
+
+source "config/Config-build.in"
+
+source "config/Config-devel.in"
+
+source "toolchain/Config.in"
+
+source "target/imagebuilder/Config.in"
+
+source "target/sdk/Config.in"
+
+source "target/toolchain/Config.in"
+
+source "tmp/.config-package.in"


### PR DESCRIPTION
# SPDX-License-Identifier: GPL-2.0-only
#
# Copyright (C) 2006-2013 OpenWrt.org

mainmenu "OpenWrt Configuration"

config MODULES
	option modules
	bool
	default y

config HAVE_DOT_CONFIG
	bool
	default y

HOST_OS := $(shell, uname)

config HOST_OS_LINUX
	def_bool $(shell, ./config/check-uname.sh Linux)

config HOST_OS_MACOS
	def_bool $(shell, ./config/check-uname.sh Darwin)

source "target/Config.in"

source "config/Config-images.in"

source "config/Config-build.in"

source "config/Config-devel.in"

source "toolchain/Config.in"

source "target/imagebuilder/Config.in"

source "target/sdk/Config.in"

source "target/toolchain/Config.in"

source "tmp/.config-package.in"

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
